### PR TITLE
Ensure exactly 1 definition per variable for building with -fno-common

### DIFF
--- a/src/cairo_ocaml.h.p
+++ b/src/cairo_ocaml.h.p
@@ -25,7 +25,7 @@
 /* cairo_t
 ***********************************************************************/
 #define CAIRO_VAL(v) (* (cairo_t **) Data_custom_val(v))
-struct custom_operations caml_cairo_ops;
+CAMLextern struct custom_operations caml_cairo_ops;
 
 void caml_cairo_raise_Error(cairo_status_t status);
 /* raise [Cairo.Error] if the status indicates a failure. */
@@ -33,7 +33,7 @@ void caml_cairo_raise_Error(cairo_status_t status);
 /* cairo_pattern_t
 ***********************************************************************/
 #define PATTERN_VAL(v) (* (cairo_pattern_t **) Data_custom_val(v))
-struct custom_operations caml_pattern_ops;
+CAMLextern struct custom_operations caml_pattern_ops;
 
 #define EXTEND_VAL(v) ((cairo_extend_t) Int_val(v))
 #define VAL_EXTEND(v) Val_int(v)
@@ -45,12 +45,12 @@ struct custom_operations caml_pattern_ops;
 ***********************************************************************/
 
 #define FONT_OPTIONS_VAL(v) (* (cairo_font_options_t**) Data_custom_val(v))
-struct custom_operations caml_font_options_ops;
+CAMLextern struct custom_operations caml_font_options_ops;
 
 /* cairo_font_type_t
 ***********************************************************************/
 
-value caml_cairo_font_type[5];
+CAMLextern value caml_cairo_font_type[5];
 
 cairo_font_type_t caml_cairo_font_type_val(value vft);
 
@@ -61,13 +61,13 @@ cairo_font_type_t caml_cairo_font_type_val(value vft);
 ***********************************************************************/
 
 #define SCALED_FONT_VAL(v) (* (cairo_scaled_font_t**) Data_custom_val(v))
-struct custom_operations caml_scaled_font_ops;
+CAMLextern struct custom_operations caml_scaled_font_ops;
 
 /* cairo_surface_t
 ***********************************************************************/
 
 #define SURFACE_VAL(v) (* (cairo_surface_t **) Data_custom_val(v))
-struct custom_operations caml_surface_ops;
+CAMLextern struct custom_operations caml_surface_ops;
 
 /* Type cairo_content_t */
 
@@ -93,7 +93,7 @@ struct custom_operations caml_surface_ops;
 ***********************************************************************/
 
 #define PATH_VAL(v) (* (cairo_path_t **) Data_custom_val(v))
-struct custom_operations caml_path_ops;
+CAMLextern struct custom_operations caml_path_ops;
 
 #define PATH_DATA_ASSIGN(vdata, data)                                   \
   switch (data->header.type) {                                          \
@@ -151,10 +151,10 @@ struct custom_operations caml_path_ops;
 #include <cairo-ft.h>
 
 #define FT_LIBRARY_VAL(v) (* (FT_Library*) Data_custom_val(v))
-struct custom_operations caml_cairo_ft_library_ops;
+CAMLextern struct custom_operations caml_cairo_ft_library_ops;
 
 #define FT_FACE_VAL(v) (* (FT_Face*) Data_custom_val(v))
-struct custom_operations caml_cairo_ft_face_ops;
+CAMLextern struct custom_operations caml_cairo_ft_face_ops;
 
 #endif /* OCAML_CAIRO_HAS_FT */
 

--- a/src/cairo_ocaml_types.h
+++ b/src/cairo_ocaml_types.h
@@ -267,14 +267,6 @@ static intnat caml_cairo_font_options_hash(value v)
   return(cairo_font_options_hash(FONT_OPTIONS_VAL(v)));
 }
 
-struct custom_operations caml_font_options_ops = {
-  "font_options_t", /* identifier for serialization and deserialization */
-  &caml_cairo_font_options_finalize,
-  &caml_cairo_font_options_compare,
-  &caml_cairo_font_options_hash,
-  custom_serialize_default,
-  custom_deserialize_default };
-
 
 /* caml_cairo_font_type is defined in "cairo_ocaml.h". */
 CAMLexport value caml_cairo_font_type_init(value unit)

--- a/src/cairo_stubs.c
+++ b/src/cairo_stubs.c
@@ -34,6 +34,27 @@
 #include "cairo_macros.h"
 #include "cairo_ocaml_types.h"
 
+CAMLexport value caml_cairo_font_type[5];
+
+CAMLexport struct custom_operations caml_cairo_ops;
+CAMLexport struct custom_operations caml_pattern_ops;
+CAMLexport struct custom_operations caml_scaled_font_ops;
+CAMLexport struct custom_operations caml_surface_ops;
+CAMLexport struct custom_operations caml_path_ops;
+
+#ifdef OCAML_CAIRO_HAS_FT
+CAMLexport struct custom_operations caml_cairo_ft_library_ops;
+CAMLexport struct custom_operations caml_cairo_ft_face_ops;
+#endif
+
+CAMLexport struct custom_operations caml_font_options_ops = {
+  "font_options_t", /* identifier for serialization and deserialization */
+  &caml_cairo_font_options_finalize,
+  &caml_cairo_font_options_compare,
+  &caml_cairo_font_options_hash,
+  custom_serialize_default,
+  custom_deserialize_default };
+
 /* cairo_t functions.
 ***********************************************************************/
 


### PR DESCRIPTION
GCC 10 is changing the default from -fcommon to -fno-common.  This patch fixes some variables that could have definitions in multiple translation units so that they are defined in exactly one translation unit.