### PR TITLE
handle safe-string

### DIFF
--- a/src/cairo_macros.h
+++ b/src/cairo_macros.h
@@ -173,7 +173,7 @@
 
 /* holds the pointer to the Unavailable exception; shared several
    functions. */
-value * caml_cairo_Unavailable = NULL;
+const value * caml_cairo_Unavailable = NULL;
 
 #define RAISE_UNAVAILABLE(name, args ...)                               \
   CAMLexport value caml_##name(args)                                    \

--- a/src/cairo_ocaml_types.h
+++ b/src/cairo_ocaml_types.h
@@ -45,7 +45,7 @@ DEFINE_CUSTOM_OPERATIONS(cairo, cairo_destroy, CAIRO_VAL)
 /* raise [Error] if the status indicates a failure. */
 void caml_cairo_raise_Error(cairo_status_t status)
 {
-  static value * exn = NULL;
+  static const value * exn = NULL;
 
   if (status != CAIRO_STATUS_SUCCESS) {
     if (exn == NULL) {

--- a/src/cairo_stubs.c
+++ b/src/cairo_stubs.c
@@ -1681,7 +1681,7 @@ static cairo_status_t caml_cairo_output_string
   CAMLlocal2(s, r);
 
   s = caml_alloc_string(length);
-  memmove(String_val(s), data, length);
+  memmove(&Byte(String_val(s), 0), data, length);
   r = caml_callback_exn(* ((value *) fn), s);
   if (Is_exception_result(r))
     CAMLreturn(CAIRO_STATUS_WRITE_ERROR);


### PR DESCRIPTION
String_val() returns 'const char *'.
caml_named_value returns 'const value *'.

Signed-off-by: Olaf Hering <olaf@aepfle.de>