### PR TITLE
Pass -fcommon for relaxing default behaviour of GCC10

### DIFF
--- a/pango/dune
+++ b/pango/dune
@@ -3,7 +3,7 @@
  (name        cairo_pango)
  (public_name cairo2-pango)
  (c_names     cairo_pango_stubs)
- (c_flags     :standard (:include c_flags.sexp))
+ (c_flags     :standard (:include c_flags.sexp) -fcommon)
  (c_library_flags :standard (:include c_library_flags.sexp))
  (libraries  threads lablgtk2 cairo2)
  (synopsis "Interface between Cairo and Pango"))


### PR DESCRIPTION
Without this flag, using pango generate some troubles (`multiple definition of ...`)