### PR TITLE
Allow drawing to mmapped files

### DIFF
--- a/tests/dune
+++ b/tests/dune
@@ -1,8 +1,8 @@
 
 (executables
- (names image_create matrix_set surface_gc test_for_stream
+ (names image_create matrix_set surface_gc surface_gc_mmap test_for_stream
         test_finish test_path test_exn)
- (libraries cairo2))
+ (libraries cairo2 unix))
 
 (alias
  (name runtest)

--- a/tests/surface_gc_mmap.ml
+++ b/tests/surface_gc_mmap.ml
@@ -1,0 +1,28 @@
+open Printf
+open Cairo
+
+(* Test that using the ref-count of the surface to express its
+   dependency on the context works. *)
+let mmap_context () =
+  let s = 8 in
+  let fd = Unix.openfile "image.mmap" [O_RDWR; O_CREAT] 0o600 in
+  Unix.unlink "image.mmap";
+  Unix.ftruncate fd (s * s * 4);
+  let data =
+    Unix.map_file fd Int32 C_layout true [| s; s |]
+    |> Bigarray.array2_of_genarray
+  in
+  let surf = Image.create_for_data32 data in
+  Gc.finalise (fun _ -> eprintf "`surf' is collected by the GC.\n%!") surf;
+  create surf
+
+let () =
+  Gc.compact();  Gc.compact();
+  let cr = mmap_context() in
+  Gc.finalise (fun _ -> eprintf "`cr' is collected by the GC.\n%!") cr;
+  printf "`surf' should be garbage collected but the surface still held \
+	by `cr'.\n%!";
+  Gc.compact();  Gc.compact();
+  Surface.finish(get_target cr);
+  printf "`cr' should be garbage collected.\n%!";
+  Gc.compact();  Gc.compact()


### PR DESCRIPTION
This is needed for e.g. Wayland applications, which need to render to memory shared with the compositor.

Fixes #32.